### PR TITLE
feat: Add Voice Cloning Agent

### DIFF
--- a/agent_terminal/agents/voice_cloning_agent.py
+++ b/agent_terminal/agents/voice_cloning_agent.py
@@ -1,0 +1,94 @@
+"""An agent that clones a user's voice to respond to prompts."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import sounddevice as sd
+import soundfile as sf
+
+from .base import Agent
+from .openai_agent import OpenAIAgent
+
+if TYPE_CHECKING:
+    from chatterbox.tts import ChatterboxTTS
+
+
+class VoiceCloningAgent(Agent):
+    """
+    An agent that uses a voice sample to generate spoken responses.
+
+    This agent first generates a text response using an OpenAI model and then
+    synthesizes it into speech using the provided voice sample. The final
+    output is the played audio.
+    """
+
+    def __init__(self, model: str, audio_path: str) -> None:
+        """
+        Initializes the VoiceCloningAgent.
+
+        Args:
+            model: The name of the OpenAI model to use for text generation.
+            audio_path: The path to the audio file for voice cloning.
+        """
+        if not Path(audio_path).is_file():
+            raise FileNotFoundError(f"Audio file not found at: {audio_path}")
+
+        self.model = model
+        self.audio_path = audio_path
+        self.text_agent = OpenAIAgent(model=self.model)
+        self.tts_model: "ChatterboxTTS | None" = None
+
+    async def _lazy_load_model(self) -> None:
+        """Load the TTS model on demand to avoid slow startup times."""
+        if self.tts_model is None:
+            import torch
+            from chatterbox.tts import ChatterboxTTS
+
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.tts_model = ChatterboxTTS.from_pretrained(device=device)
+
+    async def get_response(self, prompt: str) -> str:
+        """
+        Generates a text response and synthesizes it as spoken audio.
+
+        Args:
+            prompt: The user's input prompt.
+
+        Returns:
+            A message indicating that the audio response is being played.
+        """
+        await self._lazy_load_model()
+        text_response = await self.text_agent.get_response(prompt)
+
+        # Generate audio from the text response
+        wav = self.tts_model.generate(
+            text_response,
+            audio_prompt_path=self.audio_path,
+        )
+
+        # Save the generated audio to a temporary file
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as fp:
+            sf.write(fp.name, wav.squeeze().cpu().numpy(), self.tts_model.sr)
+            temp_audio_path = fp.name
+
+        # Play the audio in a separate thread to avoid blocking
+        asyncio.create_task(self._play_audio(temp_audio_path))
+
+        return f"Playing audio response for: '{prompt}'"
+
+    async def _play_audio(self, audio_path: str) -> None:
+        """
+        Plays the audio file at the given path.
+
+        Args:
+            audio_path: The path to the audio file to play.
+        """
+        try:
+            data, fs = sf.read(audio_path, dtype="float32")
+            sd.play(data, fs)
+            sd.wait()
+        finally:
+            # Clean up the temporary file
+            Path(audio_path).unlink()

--- a/agent_terminal/app.py
+++ b/agent_terminal/app.py
@@ -1,12 +1,15 @@
 """The main application for the Agent Terminal."""
 
+from pathlib import Path
+
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
 from textual.widgets import Footer, Header, Input, TabbedContent, TabPane
 
 from agent_terminal.agents.base import Agent
-from agent_terminal.agents.openai_agent import OpenAIAgent
 from agent_terminal.agents.ollama_agent import OllamaAgent
+from agent_terminal.agents.openai_agent import OpenAIAgent
+from agent_terminal.agents.voice_cloning_agent import VoiceCloningAgent
 from agent_terminal.screens import AgentSelectionScreen
 from agent_terminal.widgets.agent_view import AgentView
 
@@ -21,7 +24,11 @@ class AgentTerminal(App):
         ("q", "quit", "Quit"),
     ]
 
-    agent_classes = {"OpenAIAgent": OpenAIAgent, "OllamaAgent": OllamaAgent}
+    agent_classes = {
+        "OpenAIAgent": OpenAIAgent,
+        "OllamaAgent": OllamaAgent,
+        "VoiceCloningAgent": VoiceCloningAgent,
+    }
 
     def __init__(self) -> None:
         """Initialize the app."""
@@ -34,7 +41,9 @@ class AgentTerminal(App):
         yield Header()
         with Vertical():
             yield TabbedContent(id="agents")
-            yield Input(placeholder="Enter your prompt here...", id="prompt_input", disabled=True)
+            yield Input(
+                placeholder="Enter your prompt here...", id="prompt_input", disabled=True
+            )
         yield Footer()
 
     def on_mount(self) -> None:
@@ -57,21 +66,32 @@ class AgentTerminal(App):
             agent_view = active_pane.query_one(AgentView)
 
             if not agent:
-                agent_view.add_message("System", "[bold red]No agent is active for this tab.[/bold red]")
+                agent_view.add_message(
+                    "System", "[bold red]No agent is active for this tab.[/bold red]"
+                )
                 return
 
             agent_view.add_message("User", prompt)
             input_widget.clear()
             input_widget.disabled = True
-            agent_view.add_message("System", "[italic]Agent is thinking...[/italic]", sender_style="dim")
+            agent_view.add_message(
+                "System", "[italic]Agent is thinking...[/italic]", sender_style="dim"
+            )
 
             response = await agent.get_response(prompt)
-            agent_view.add_message(agent.__class__.__name__, response, sender_style="bold blue")
+            agent_view.add_message(
+                agent.__class__.__name__, response, sender_style="bold blue"
+            )
 
             input_widget.disabled = False
             input_widget.focus()
 
-    def _add_agent_tab(self, agent_class_name: str, model_name: str) -> None:
+    def _add_agent_tab(
+        self,
+        agent_class_name: str,
+        model_name: str,
+        audio_path: str | None = None,
+    ) -> None:
         """Creates a new agent and its corresponding tab."""
         self.agent_count += 1
         pane_id = f"agent_{self.agent_count}"
@@ -79,45 +99,59 @@ class AgentTerminal(App):
 
         try:
             agent_class = self.agent_classes[agent_class_name]
-            agent = agent_class(model=model_name)
+
+            if agent_class_name == "VoiceCloningAgent":
+                if not audio_path:
+                    raise ValueError("Audio path is required for VoiceCloningAgent.")
+                agent = agent_class(model=model_name, audio_path=audio_path)
+                pane_title = f"VC: {Path(audio_path).stem}"
+            else:
+                agent = agent_class(model=model_name)
+                pane_title = f"{agent_class_name}: {model_name}"
+
             self.agents[pane_id] = agent
 
             agent_view = AgentView()
-            pane_title = f"{agent_class_name}: {model_name}"
-            agent_view.add_message("System", f"Agent '{pane_title}' started.", sender_style="bold green")
+            agent_view.add_message(
+                "System", f"Agent '{pane_title}' started.", sender_style="bold green"
+            )
 
             new_pane = TabPane(pane_title, agent_view, id=pane_id)
             tabs.add_pane(new_pane)
             tabs.active = pane_id
             self.query_one("#prompt_input", Input).disabled = False
 
-        except ValueError as e:
-            # Handle errors like missing API keys gracefully.
+        except (ValueError, FileNotFoundError) as e:
             agent_view = AgentView()
             pane_title = f"Error: {agent_class_name}"
-            agent_view.add_message("System", f"[bold red]Failed to create agent: {e}[/bold red]")
-
+            agent_view.add_message(
+                "System", f"[bold red]Failed to create agent: {e}[/bold red]"
+            )
             new_pane = TabPane(pane_title, agent_view, id=pane_id)
             tabs.add_pane(new_pane)
             tabs.active = pane_id
         except Exception as e:
-            # Catch any other unexpected errors during agent initialization.
             agent_view = AgentView()
             pane_title = "Initialization Error"
-            agent_view.add_message("System", f"[bold red]An unexpected error occurred: {e}[/bold red]")
-
+            agent_view.add_message(
+                "System", f"[bold red]An unexpected error occurred: {e}[/bold red]"
+            )
             new_pane = TabPane(pane_title, agent_view, id=pane_id)
             tabs.add_pane(new_pane)
             tabs.active = pane_id
 
     def action_add_agent(self) -> None:
         """Show the agent selection screen and add a new agent tab."""
-        def on_select_closed(result: tuple[str, str] | None) -> None:
+
+        def on_select_closed(result: tuple | None) -> None:
             if result:
-                agent_class_name, model_name = result
-                self._add_agent_tab(agent_class_name, model_name)
+                if len(result) == 3:
+                    agent_class_name, model_name, audio_path = result
+                    self._add_agent_tab(agent_class_name, model_name, audio_path)
+                else:
+                    agent_class_name, model_name = result
+                    self._add_agent_tab(agent_class_name, model_name)
             elif not self.agents:
-                # If the user cancels the first dialog, quit the app.
                 self.exit()
 
         self.push_screen(AgentSelectionScreen(), on_select_closed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = [
     "textual==0.66.0",
     "openai==1.30.1",
     "ollama==0.2.1",
+    "chatterbox-tts==0.1.2",
+    "soundfile==0.12.1",
+    "sounddevice==0.4.6",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,12 +27,18 @@ mock_ollama_agent_instance.get_response = AsyncMock(return_value=MOCK_RESPONSE)
 MockOpenAIAgent = MagicMock(return_value=mock_openai_agent_instance)
 MockOllamaAgent = MagicMock(return_value=mock_ollama_agent_instance)
 
+# Mock the VoiceCloningAgent to prevent model downloads during tests
+mock_vc_agent_instance = MagicMock()
+mock_vc_agent_instance.get_response = AsyncMock(return_value=MOCK_RESPONSE)
+MockVoiceCloningAgent = MagicMock(return_value=mock_vc_agent_instance)
+
 
 @patch.dict(
     "agent_terminal.app.AgentTerminal.agent_classes",
     {
         "OpenAIAgent": MockOpenAIAgent,
         "OllamaAgent": MockOllamaAgent,
+        "VoiceCloningAgent": MockVoiceCloningAgent,
     },
 )
 class TestAgentTerminal:

--- a/tests/test_voice_cloning_agent.py
+++ b/tests/test_voice_cloning_agent.py
@@ -1,0 +1,105 @@
+"""Unit tests for the VoiceCloningAgent."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent_terminal.agents.voice_cloning_agent import VoiceCloningAgent
+
+
+@pytest.fixture
+def mock_dependencies():
+    """Mocks all external dependencies for the VoiceCloningAgent."""
+    with patch(
+        "agent_terminal.agents.voice_cloning_agent.OpenAIAgent", autospec=True
+    ) as mock_openai_agent, patch(
+        "chatterbox.tts.ChatterboxTTS", autospec=True
+    ) as mock_chatterbox, patch(
+        "agent_terminal.agents.voice_cloning_agent.sf", autospec=True
+    ) as mock_soundfile, patch(
+        "agent_terminal.agents.voice_cloning_agent.sd", autospec=True
+    ) as mock_sounddevice, patch(
+        "agent_terminal.agents.voice_cloning_agent.Path.is_file", return_value=True
+    ), patch(
+        "agent_terminal.agents.voice_cloning_agent.Path.unlink"
+    ) as mock_unlink:
+        # Configure the ChatterboxTTS mock
+        mock_tts_instance = MagicMock()
+        mock_tts_instance.generate.return_value = MagicMock()  # Mock waveform
+        mock_chatterbox.from_pretrained.return_value = mock_tts_instance
+
+        # Configure the OpenAIAgent mock
+        mock_openai_instance = MagicMock()
+        mock_openai_instance.get_response = AsyncMock(
+            return_value="This is a test response."
+        )
+        mock_openai_agent.return_value = mock_openai_instance
+
+        # Configure the soundfile mock to return dummy data
+        mock_soundfile.read.return_value = (MagicMock(), 44100)
+
+        yield {
+            "openai_agent": mock_openai_agent,
+            "chatterbox": mock_chatterbox,
+            "soundfile": mock_soundfile,
+            "sounddevice": mock_sounddevice,
+            "unlink": mock_unlink,
+            "tts_instance": mock_tts_instance,
+            "openai_instance": mock_openai_instance,
+        }
+
+
+def test_initialization_success(mock_dependencies):
+    """Test that the VoiceCloningAgent initializes successfully without loading the model."""
+    agent = VoiceCloningAgent(model="gpt-4o", audio_path="/fake/path/voice.wav")
+    assert agent.model == "gpt-4o"
+    assert agent.audio_path == "/fake/path/voice.wav"
+    assert agent.tts_model is None
+    mock_dependencies["chatterbox"].from_pretrained.assert_not_called()
+    mock_dependencies["openai_agent"].assert_called_once_with(model="gpt-4o")
+
+
+def test_initialization_file_not_found():
+    """Test that initialization raises FileNotFoundError if the audio path is invalid."""
+    with patch("agent_terminal.agents.voice_cloning_agent.Path.is_file", return_value=False):
+        with pytest.raises(FileNotFoundError, match="Audio file not found at: /invalid/path.wav"):
+            VoiceCloningAgent(model="gpt-4o", audio_path="/invalid/path.wav")
+
+
+@pytest.mark.asyncio
+async def test_get_response(mock_dependencies):
+    """Test the complete get_response flow, including lazy model loading."""
+    agent = VoiceCloningAgent(model="gpt-4o", audio_path="/fake/path/voice.wav")
+    assert agent.tts_model is None
+
+    prompt = "Tell me a story."
+    response = await agent.get_response(prompt)
+
+    # Verify the agent returns the correct status message
+    assert response == f"Playing audio response for: '{prompt}'"
+
+    # Verify the TTS model was lazy-loaded
+    mock_dependencies["chatterbox"].from_pretrained.assert_called_once()
+    assert agent.tts_model is not None
+
+    # Verify the text agent was called correctly
+    mock_dependencies["openai_instance"].get_response.assert_awaited_once_with(prompt)
+
+    # Verify the TTS model was used correctly
+    mock_dependencies["tts_instance"].generate.assert_called_once_with(
+        "This is a test response.",
+        audio_prompt_path="/fake/path/voice.wav",
+    )
+
+    # Verify the audio was saved
+    mock_dependencies["soundfile"].write.assert_called_once()
+
+    # Allow the async _play_audio task to run
+    await asyncio.sleep(0.01)
+
+    # Verify audio playback and cleanup
+    mock_dependencies["sounddevice"].play.assert_called_once()
+    mock_dependencies["sounddevice"].wait.assert_called_once()
+    mock_dependencies["unlink"].assert_called_once()


### PR DESCRIPTION
This commit introduces a new `VoiceCloningAgent` that integrates the `chatterbox-tts` library to provide voice cloning functionality within the AgentTerminal application.

The new agent allows users to provide a `.wav` file as a voice sample. When a prompt is submitted, the agent first generates a text response using an underlying OpenAI model and then synthesizes the text into speech using the cloned voice. The generated audio is then played back to the user.

Key changes:
- Created `agent_terminal/agents/voice_cloning_agent.py` to house the new agent logic.
- Implemented lazy-loading for the `chatterbox-tts` and `torch` libraries to avoid slow startup times and resolve test collection timeouts. The models are now loaded on-demand when `get_response` is first called.
- Updated `agent_terminal/screens.py` to add the `VoiceCloningAgent` to the selection screen and include a conditional input field for the reference audio file path.
- Modified `agent_terminal/app.py` to handle the instantiation and management of the new agent type.
- Added `chatterbox-tts`, `soundfile`, and `sounddevice` as dependencies in `pyproject.toml`.
- Created `tests/test_voice_cloning_agent.py` with comprehensive unit tests that mock all external dependencies, including the TTS model and audio playback functions.
- Updated `tests/test_app.py` to correctly mock the `VoiceCloningAgent`, ensuring the application's test suite can run without triggering heavyweight model downloads.